### PR TITLE
rename api/calendar to api/calendars

### DIFF
--- a/backend/app/src/main/java/ch/zhaw/studyflow/controllers/CalendarController.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/controllers/CalendarController.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * Controller for handling calendar-related HTTP requests.
  * Provides endpoints for creating, reading, updating, and deleting calendars and appointments.
  */
-@Route(path = "api/calendar")
+@Route(path = "api/calendars")
 public class CalendarController {
     private final CalendarManager calendarManager;
     private final AppointmentManager appointmentManager;

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/Settings.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/Settings.java
@@ -8,6 +8,11 @@ public class Settings {
     private long globalCalendarId;
     private long activeDegree;
 
+    public Settings() {
+        this.globalCalendarId   = -1;
+        this.activeDegree       = -1;
+    }
+
     @JsonGetter("id")
     public long getId() {
         return settingsId;


### PR DESCRIPTION
As the title says, this pull request renames the api/calendar route to api/calendars