### PR TITLE
add title field and set id = -1

### DIFF
--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/Appointment.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/Appointment.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
  */
 public class Appointment {
     private long id;
+    private String title;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private long calendarId;
@@ -16,7 +17,9 @@ public class Appointment {
     /**
      * Default constructor.
      */
-    public Appointment() {}
+    public Appointment() {
+        this.id = -1;
+    }
 
     /**
      * Constructs an appointment with the specified details.
@@ -51,6 +54,26 @@ public class Appointment {
     @JsonSetter("id")
     public void setId(long id) {
         this.id = id;
+    }
+
+    /**
+     * Gets the title of the appointment.
+     *
+     * @return the title of the appointment
+     */
+    @JsonGetter("title")
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Sets the title of the appointment.
+     *
+     * @param title the new title of the appointment
+     */
+    @JsonSetter("title")
+    public void setTitle(String title) {
+        this.title  = title;
     }
 
     /**

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/Calendar.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/Calendar.java
@@ -14,7 +14,9 @@ public class Calendar {
     /**
      * Default constructor.
      */
-    public Calendar() {}
+    public Calendar() {
+        this.id = -1;
+    }
 
     /**
      * Constructs a calendar with the specified ID, name, and owner ID.

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/grade/Grade.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/grade/Grade.java
@@ -16,7 +16,9 @@ public class Grade {
     /**
      * Default constructor.
      */
-    public Grade() {}
+    public Grade() {
+        this.id = -1;
+    }
 
     /**
      * Constructs a grade with the specified ID, name, percentage, value, and module ID.

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/Settings.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/Settings.java
@@ -4,23 +4,24 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 public class Settings {
-    private long settingsId;
+    private long id;
     private long globalCalendarId;
     private long activeDegree;
 
     public Settings() {
+        this.id                 = -1;
         this.globalCalendarId   = -1;
         this.activeDegree       = -1;
     }
 
     @JsonGetter("id")
     public long getId() {
-        return settingsId;
+        return id;
     }
 
     @JsonSetter("id")
-    public void setId(long settingsId) {
-        this.settingsId = settingsId;
+    public void setId(long id) {
+        this.id = id;
     }
 
     @JsonGetter("globalCalendar")


### PR DESCRIPTION
This pull request adds the "title" field to the Appointment model and sets the ID to -1 where this is not already the case. I also renamed the Settings 'settingsId' field to 'id' internally to make it more consistent with the rest of the models (this does not affect the client).