### PR TITLE
Add update appointment endpoint

### DIFF
--- a/backend/app/src/main/java/ch/zhaw/studyflow/controllers/CalendarController.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/controllers/CalendarController.java
@@ -5,7 +5,6 @@ import ch.zhaw.studyflow.domain.calendar.AppointmentManager;
 import ch.zhaw.studyflow.domain.calendar.Calendar;
 import ch.zhaw.studyflow.domain.calendar.CalendarManager;
 import ch.zhaw.studyflow.utils.LongUtils;
-import ch.zhaw.studyflow.utils.Tuple;
 import ch.zhaw.studyflow.webserver.annotations.Endpoint;
 import ch.zhaw.studyflow.webserver.annotations.Route;
 import ch.zhaw.studyflow.webserver.http.HttpMethod;
@@ -14,7 +13,6 @@ import ch.zhaw.studyflow.webserver.http.HttpResponse;
 import ch.zhaw.studyflow.webserver.http.HttpStatusCode;
 import ch.zhaw.studyflow.webserver.http.contents.JsonContent;
 import ch.zhaw.studyflow.webserver.http.pipeline.RequestContext;
-import ch.zhaw.studyflow.webserver.http.query.QueryParameters;
 import ch.zhaw.studyflow.webserver.security.authentication.AuthenticationHandler;
 import ch.zhaw.studyflow.webserver.security.principal.CommonClaims;
 
@@ -211,6 +209,35 @@ public class CalendarController {
                     response.setResponseBody(JsonContent.writableOf(foundAppointment))
                             .setStatusCode(HttpStatusCode.OK);
                 }
+            }
+            return response;
+        });
+    }
+
+    @Route(path = "{calendarId}/appointments/{appointmentId}")
+    @Endpoint(method = HttpMethod.POST)
+    public HttpResponse updateAppointment(RequestContext context) {
+        final HttpRequest request = context.getRequest();
+
+        return authenticator.handleIfAuthenticated(request, principal -> {
+            final HttpResponse response = request.createResponse()
+                    .setStatusCode(HttpStatusCode.BAD_REQUEST);
+
+            final Optional<Long> calendarId = context.getUrlCaptures().get("calendarId").flatMap(LongUtils::tryParseLong);
+            final Optional<Long> appointmentId = context.getUrlCaptures().get("appointmentId").flatMap(LongUtils::tryParseLong);
+            if (calendarId.isPresent() && appointmentId.isPresent()) {
+                request.getRequestBody()
+                        .flatMap(body -> body.tryRead(Appointment.class))
+                        .flatMap(appointment -> {
+                            appointment.setId(appointmentId.get());
+                            appointment.setCalendarId(calendarId.get());
+                            appointmentManager.update(appointment);
+                            return Optional.of(appointment);
+                        })
+                        .ifPresent(appointment -> {
+                            response.setResponseBody(JsonContent.writableOf(appointment))
+                                    .setStatusCode(HttpStatusCode.OK);
+                        });
             }
             return response;
         });

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/impls/AppointmentManagerImpl.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/calendar/impls/AppointmentManagerImpl.java
@@ -4,7 +4,6 @@ import ch.zhaw.studyflow.domain.calendar.Appointment;
 import ch.zhaw.studyflow.domain.calendar.AppointmentManager;
 import ch.zhaw.studyflow.services.persistence.AppointmentDao;
 
-import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -44,6 +43,14 @@ public class AppointmentManagerImpl implements AppointmentManager {
 
     @Override
     public void update(Appointment appointment) {
-        appointmentDao.update(appointment);
+        Appointment appointmentToUpdate = appointmentDao.read(appointment.getCalendarId(), appointment.getId());
+
+        if (appointmentToUpdate != null) {
+            appointmentToUpdate.setTitle(appointment.getTitle());
+            appointmentToUpdate.setDescription(appointment.getDescription());
+            appointmentToUpdate.setStartTime(appointment.getStartTime());
+            appointmentToUpdate.setEndTime(appointment.getEndTime());
+            appointmentDao.update(appointmentToUpdate);
+        }
     }
 }

--- a/backend/app/src/test/java/ch/zhaw/studyflow/controllers/CalendarControllerTest.java
+++ b/backend/app/src/test/java/ch/zhaw/studyflow/controllers/CalendarControllerTest.java
@@ -128,13 +128,7 @@ class CalendarControllerTest {
         assertInstanceOf(JsonContent.class, responseBodyCaptor.getValue());
         assertEquals(HttpStatusCode.OK, statusCodeCaptor.getValue());
     }
-
-    private static void validateDate(LocalDate expected, LocalDate actual) {
-        if (!expected.equals(actual)) {
-            throw new AssertionError("Expected " + expected + " but was " + actual);
-        }
-    }
-
+    
     @Test
     void testGetAppointment() {
         Appointment appointment = new Appointment();
@@ -156,6 +150,30 @@ class CalendarControllerTest {
         final ArgumentCaptor<HttpStatusCode> statusCodeCaptor = HttpMockHelpers.captureResponseCode(actualResponse);
         assertInstanceOf(JsonContent.class, responseBodyCaptor.getValue());
         assertEquals(HttpStatusCode.OK, statusCodeCaptor.getValue());
+    }
+    
+    @Test
+    void testUpdateAppointment() {
+        Appointment appointment = new Appointment();
+        appointment.setTitle("Test");
+        appointment.setStartTime(LocalDateTime.now());
+        appointment.setEndTime(LocalDateTime.now().plusHours(1));
+
+        AuthMockHelpers.configureSuccessfulAuthHandler(authenticator, AuthMockHelpers.getDefaultClaims());
+
+        final ReadableBodyContent bodyContent = makeJsonRequestBody(Appointment.class, appointment);
+        final HttpRequest request = makeHttpRequest(bodyContent);
+        final RequestContext context = makeRequestContext(request, Map.of("calendarId", "1", "appointmentId", "2"));
+
+        final HttpResponse actualResponse = calendarController.updateAppointment(context);
+        final ArgumentCaptor<HttpStatusCode> statusCodeCaptor = HttpMockHelpers.captureResponseCode(actualResponse);
+
+        verify(appointmentManager, times(1)).update(appointment);
+        assertEquals(HttpStatusCode.OK, statusCodeCaptor.getValue());
+
+        verify(appointmentManager, times(1)).update(appointment);
+        assertEquals(1, appointment.getCalendarId());
+        assertEquals(2, appointment.getId());
     }
 
     @Test

--- a/backend/app/src/test/java/ch/zhaw/studyflow/domain/appointment/AppointmentManagerTest.java
+++ b/backend/app/src/test/java/ch/zhaw/studyflow/domain/appointment/AppointmentManagerTest.java
@@ -26,7 +26,8 @@ class AppointmentManagerTest {
 
     @Test
     void testCreate() {
-        Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
+        final Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
+
         doNothing().when(appointmentDao).create(appointment);
 
         appointmentManager.create(appointment);
@@ -35,7 +36,8 @@ class AppointmentManagerTest {
 
     @Test
     void testRead() {
-        Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
+        final Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
+
         when(appointmentDao.read(1L, 1L)).thenReturn(appointment);
 
         Appointment readAppointment = appointmentManager.read(1L, 1L);
@@ -45,8 +47,9 @@ class AppointmentManagerTest {
 
     @Test
     void testReadAllBy() {
-        Appointment appointment1 = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
-        Appointment appointment2 = new Appointment(2, LocalDateTime.now().plusHours(2), LocalDateTime.now().plusHours(3), 1L, "Test", "Test");
+        final Appointment appointment1 = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
+        final Appointment appointment2 = new Appointment(2, LocalDateTime.now().plusHours(2), LocalDateTime.now().plusHours(3), 1L, "Test", "Test");
+
         when(appointmentDao.readAllBy(1L)).thenReturn(List.of(appointment1, appointment2));
 
         List<Appointment> appointments = appointmentManager.readAllBy(1L);
@@ -66,10 +69,24 @@ class AppointmentManagerTest {
 
     @Test
     void testUpdate() {
-        Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1L, "Test", "Test");
-        doNothing().when(appointmentDao).update(appointment);
+        final Appointment appointment = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(1), 1, "Test", "Test");
+        final Appointment updatesToApply = new Appointment(1, LocalDateTime.now(), LocalDateTime.now().plusHours(2), 27, "1234", "4321");
 
-        appointmentManager.update(appointment);
+        when(appointmentDao.read(27, 1)).thenReturn(appointment);
+
+
+        appointmentManager.update(updatesToApply);
+        verify(appointmentDao).read(27, 1);
         verify(appointmentDao).update(appointment);
+
+        /* Assert mutable properties */
+        assertEquals(updatesToApply.getTitle(), appointment.getTitle());
+        assertEquals(updatesToApply.getDescription(), appointment.getDescription());
+        assertEquals(updatesToApply.getStartTime(), appointment.getStartTime());
+        assertEquals(updatesToApply.getEndTime(), appointment.getEndTime());
+
+        /* Assert immutable properties */
+        assertEquals(1, appointment.getId());
+        assertEquals(1, appointment.getCalendarId());
     }
 }


### PR DESCRIPTION
As the title says, this pull request adds the update appointment endpoint.
Route: api/calendars/{calendarId}/appointments/{appointmentId}
The endpoint expects an Appointment in the body and allows setting the title, description, start and end time.