### PR TITLE
Always update models explicitly

### DIFF
--- a/backend/app/src/main/java/ch/zhaw/studyflow/controllers/SemesterController.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/controllers/SemesterController.java
@@ -45,11 +45,11 @@ public class SemesterController {
                         .flatMap(body -> body.tryRead(SemesterDeo.class));
                 Optional<Long> userId = principal.getClaim(CommonClaims.USER_ID);
                 if(semesterDeo.isPresent() && semesterDeo.get().isValid()) {
-                        semesterDeo.map(obj -> {
+                        semesterDeo.map(deo -> {
                             Semester semester = new Semester();
-                            semester.setName(obj.getName());
-                            semester.setDescription(obj.getDescription());
-                            semester.setDegreeId(obj.getDegreeId());
+                            semester.setName(deo.getName());
+                            semester.setDescription(deo.getDescription());
+                            semester.setDegreeId(deo.getDegreeId());
                             semester.setUserId(userId.get());
                             return semester;
                         }).ifPresentOrElse(semester -> {

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/DegreeManagerImpl.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/DegreeManagerImpl.java
@@ -60,10 +60,12 @@ public class DegreeManagerImpl implements DegreeManager {
         }
 
         Degree degreeFromDatabase = degreeDao.read(degree.getId());
-        degreeFromDatabase.setName(degree.getName());
-        degreeFromDatabase.setDescription(degree.getDescription());
-        degreeFromDatabase.setActiveSemesterId(degree.getActiveSemesterId());
-        degreeDao.update(degree);
+        if (degreeFromDatabase != null) {
+            degreeFromDatabase.setName(degree.getName());
+            degreeFromDatabase.setDescription(degree.getDescription());
+            degreeFromDatabase.setActiveSemesterId(degree.getActiveSemesterId());
+            degreeDao.update(degree);
+        }
     }
 
     @Override

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/ModuleManagerImpl.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/ModuleManagerImpl.java
@@ -92,6 +92,15 @@ public class ModuleManagerImpl implements ModuleManager {
      * @param module the module to update
      */
     public void update(Module module) {
-        moduleDao.update(module);
+        Module moduleToUpdate = moduleDao.read(module.getId());
+        if (moduleToUpdate != null) {
+            moduleToUpdate.setName(module.getName());
+            moduleToUpdate.setDescription(module.getDescription());
+            moduleToUpdate.setECTS(module.getECTS());
+            moduleToUpdate.setComplexity(module.getComplexity());
+            moduleToUpdate.setTime(module.getTime());
+            moduleToUpdate.setUnderstanding(module.getUnderstanding());
+            moduleDao.update(moduleToUpdate);
+        }
     }
 }

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/SemesterManagerImpl.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/curriculum/impls/SemesterManagerImpl.java
@@ -41,7 +41,13 @@ public class SemesterManagerImpl implements SemesterManager {
 
     @Override
     public void updateSemester(Semester semester) {
-        semesterDao.updateSemester(semester);
+        semesterDao.getSemesterById(semester.getId())
+                .ifPresent(semesterToUpdate -> {
+                    semesterToUpdate.setName(semester.getName());
+                    semesterToUpdate.setDescription(semester.getDescription());
+                    this.semesterDao.updateSemester(semesterToUpdate);
+                }
+        );
     }
 
     @Override

--- a/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/impls/StudentManagerImpl.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/domain/student/impls/StudentManagerImpl.java
@@ -62,7 +62,11 @@ public class StudentManagerImpl implements StudentManager {
 
     @Override
     public void updateSettings(Settings settings) {
-        settingsDao.update(settings);
+        Settings settingsToUpdate = settingsDao.read(settings.getId());
+        if (settingsToUpdate != null) {
+            settingsToUpdate.setActiveDegree(settings.getActiveDegree());
+            settingsDao.update(settingsToUpdate);
+        }
     }
 
     @Override


### PR DESCRIPTION
As discussed yesterday, this pull request changes the update methods in the manager classes so they first load the current state of the model and then update each changeable field.