### PR TITLE
rename handleIfUnauthenticated to handleRequest

### DIFF
--- a/backend/app/src/main/java/ch/zhaw/studyflow/webserver/security/authentication/AuthenticationHandler.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/webserver/security/authentication/AuthenticationHandler.java
@@ -30,11 +30,11 @@ public interface AuthenticationHandler {
     HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler);
 
     /**
-     * Checks if the request is authenticated and calls the handler function if so.
+     * Checks if the request is authenticated or unauthenticated and calls the respective handler function.
      * @param request The request to check.
      * @param handler The handler function to call if the request is authenticated.
      * @param unauthenticatedHandler The handler function to call if the request is not authenticated.
-     * @return The response of the handler function or a response with status code 401 if the request is not authenticated.
+     * @return The HTTP response of one of the two handlers.
      */
-    HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler, Function<Principal, HttpResponse> unauthenticatedHandler);
+    HttpResponse handleRequest(HttpRequest request, Function<Principal, HttpResponse> handler, Function<Principal, HttpResponse> unauthenticatedHandler);
 }

--- a/backend/app/src/main/java/ch/zhaw/studyflow/webserver/security/authentication/JwtBasedAuthenticationHandler.java
+++ b/backend/app/src/main/java/ch/zhaw/studyflow/webserver/security/authentication/JwtBasedAuthenticationHandler.java
@@ -3,17 +3,13 @@ package ch.zhaw.studyflow.webserver.security.authentication;
 import ch.zhaw.studyflow.webserver.http.HttpRequest;
 import ch.zhaw.studyflow.webserver.http.HttpResponse;
 import ch.zhaw.studyflow.webserver.http.HttpStatusCode;
-import ch.zhaw.studyflow.webserver.security.principal.Claim;
 import ch.zhaw.studyflow.webserver.security.principal.CommonClaims;
 import ch.zhaw.studyflow.webserver.security.principal.Principal;
 import ch.zhaw.studyflow.webserver.security.principal.PrincipalProvider;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
-import java.time.temporal.TemporalUnit;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -55,7 +51,7 @@ public class JwtBasedAuthenticationHandler implements AuthenticationHandler {
 
     @Override
     public HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler) {
-        return handleIfUnauthenticated(
+        return handleRequest(
                 request,
                 principal -> request.createResponse().setStatusCode(HttpStatusCode.UNAUTHORIZED),
                 handler
@@ -63,7 +59,7 @@ public class JwtBasedAuthenticationHandler implements AuthenticationHandler {
     }
 
     @Override
-    public HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler, Function<Principal, HttpResponse> unauthenticatedHandler) {
+    public HttpResponse handleRequest(HttpRequest request, Function<Principal, HttpResponse> handler, Function<Principal, HttpResponse> unauthenticatedHandler) {
         final Principal principal = principalProvider.getPrincipal(request);
         HttpResponse response = isAuthenticated(principal)
                 ? handler.apply(principal)

--- a/backend/app/src/test/java/ch/zhaw/studyflow/controllers/AuthMockHelpers.java
+++ b/backend/app/src/test/java/ch/zhaw/studyflow/controllers/AuthMockHelpers.java
@@ -9,8 +9,6 @@ import ch.zhaw.studyflow.webserver.security.principal.CommonClaims;
 import ch.zhaw.studyflow.webserver.security.principal.Principal;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -36,7 +34,7 @@ public class AuthMockHelpers {
             return request.createResponse().setStatusCode(HttpStatusCode.UNAUTHORIZED);
         });
 
-        when(authHandler.handleIfUnauthenticated(any(), any(), any())).then(invocation -> {
+        when(authHandler.handleRequest(any(), any(), any())).then(invocation -> {
             Function<Principal, HttpResponse> unauthenticatedHandler = invocation.getArgument(2);
             return unauthenticatedHandler.apply(principal);
         });
@@ -55,7 +53,7 @@ public class AuthMockHelpers {
             return handler.apply(principal);
         });
 
-        when(authHandler.handleIfUnauthenticated(any(), any(), any())).then(a -> {
+        when(authHandler.handleRequest(any(), any(), any())).then(a -> {
             Function<Principal, HttpResponse> handler = a.getArgument(1);
             return handler.apply(principal);
         });


### PR DESCRIPTION
As the title sais, this pull request renames the second of the two handleIfUnauthenticated functions below to `handleRequest` since it more appropriatly describes what the method does. The name is still not great but better then the old one.

```
public interface AuthenticationHandler {
    HttpResponse handleIfAuthenticated(HttpRequest request, Function<Principal, HttpResponse> handler);

    HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler);

    HttpResponse handleIfUnauthenticated(HttpRequest request, Function<Principal, HttpResponse> handler, Function<Principal, HttpResponse> unauthenticatedHandler);
}
```